### PR TITLE
Update to tree-sitter-c3 0.2.3

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -12,4 +12,4 @@ language = "C3"
 
 [grammars.c3]
 repository = "https://github.com/c3lang/tree-sitter-c3"
-commit = "790a0326833cd647e00d8dec01268aa1ec2e3bdb"
+commit = "10a78fbf8d3095369d32bc99840487396d899899"

--- a/languages/c3/config.toml
+++ b/languages/c3/config.toml
@@ -18,4 +18,8 @@ brackets = [
         "string",
         "comment",
     ] },
+    { start = "<*", end = " *>", close = true, newline = true, not_in = [
+        "string",
+        "comment",
+    ] }
 ]

--- a/languages/c3/highlights.scm
+++ b/languages/c3/highlights.scm
@@ -19,7 +19,7 @@
 (initializer_list (arg (param_path (param_path_element (ident) @variable.member))))
 ;; 2) Parameter
 (parameter name: (_) @variable.parameter)
-(call_invocation (arg (param_path (param_path_element [(ident) (ct_ident)] @variable.parameter))))
+(call_invocation (call_arg (ident) @variable.parameter))
 (enum_param_declaration (ident) @variable.parameter)
 ;; 3) Declaration
 (global_declaration (ident) @variable.declaration)
@@ -320,4 +320,13 @@
   (block_comment)
 ] @comment
 
-(doc_comment) @comment.documentation
+(doc_comment) @comment.doc
+(doc_comment_text) @comment.doc
+(doc_comment_contract name: (_) @emphasis.strong
+                      (#any-of? @emphasis.strong
+                                "@param"
+                                "@return"
+                                "@deprecated"
+                                "@require"
+                                "@ensure"
+                                "@pure"))

--- a/test.c3
+++ b/test.c3
@@ -20,6 +20,21 @@ fn String Person.as_str(Person* self) @dynamic
     return str.copy_str();
 }
 
+<*
+Factorial.
+@pure
+@param i
+@require i >= 0
+@ensure return >= 1
+*>
+fn int fact(int i = 0) {
+  if (i == 0) {
+    return 1;
+  } else {
+    return i * fact(i: i - 1);
+  }
+}
+
 fn void main()
 {
     Person p = {


### PR DESCRIPTION
(Actually, updates to a few commits after the 0.2.3 release, since some important fixes to contract parsing were made right afterwards.)

This update correctly highlights the latest C3 (v0.6.6) syntax, such as `<* contracts with @pure and stuff *>` and `f(new: named, arg: syntax)`.

Preview from the test file:

![image](https://github.com/user-attachments/assets/ebef93f2-a793-477e-ad27-8523d4ddcef9)