### PR TITLE
C3lsp Filename Fix

### DIFF
--- a/src/c3.rs
+++ b/src/c3.rs
@@ -12,8 +12,8 @@ impl zed::Extension for C3Extension {
         _language_server_id: &zed::LanguageServerId,
         worktree: &zed::Worktree,
     ) -> Result<zed::Command> {
-        let c3lsp_cmd = worktree.which("c3-lsp");
-        let path = c3lsp_cmd.ok_or_else(|| "c3-lsp must be in your path".to_string())?;
+        let c3lsp_cmd = worktree.which("c3lsp");
+        let path = c3lsp_cmd.ok_or_else(|| "c3lsp must be in your path".to_string())?;
 
         Ok(zed::Command {
             command: path,


### PR DESCRIPTION
The updated command and result message should be c3lsp removing the '-'. This is how the lsp server binary  is built by default." This will fix the open issue.](https://github.com/Ronin15/c3-zed.git)

Pherry Mason's makefile link:
https://github.com/pherrymason/c3-lsp/blob/main/Makefile
