### PR TITLE
update grammar

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -12,4 +12,4 @@ language = "C3"
 
 [grammars.c3]
 repository = "https://github.com/c3lang/tree-sitter-c3"
-rev = "7d5474b5038a6f890b0649457c04db0f57f642fc"
+rev = "0e4f7a008af55f3254e50b6b9e2e8936f55f7036"

--- a/languages/c3/highlights.scm
+++ b/languages/c3/highlights.scm
@@ -1,38 +1,80 @@
-;; NOTE In this file later patterns are assumed to have priority!
+; Punctuation
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+  "[<"
+  ">]"
+] @punctuation.bracket
 
-;; Punctuation
-["(" ")" "[" "]" "{" "}"] @punctuation.bracket
-[";" "," ":" "::"] @punctuation.delimiter
+[
+  ";"
+  ","
+  ":"
+  "::"
+] @punctuation.delimiter
 
-;; Constant
+; Constant
 (const_ident) @constant
-["true" "false"] @boolean
-["null"] @constant.builtin
 
-;; Variable
-[(ident) (ct_ident)] @variable
-;; 1) Member
-(field_expr field: (access_ident (ident) @variable.member))
-(struct_member_declaration (ident) @variable.member)
-(struct_member_declaration (identifier_list (ident) @variable.member))
-(bitstruct_member_declaration (ident) @variable.member)
-(initializer_list (arg (param_path (param_path_element (ident) @variable.member))))
-;; 2) Parameter
-(parameter name: (_) @variable.parameter)
-(call_invocation (call_arg (ident) @variable.parameter))
-(enum_param_declaration (ident) @variable.parameter)
-;; 3) Declaration
-(global_declaration (ident) @variable.declaration)
-(local_decl_after_type name: [(ident) (ct_ident)] @variable.declaration)
-(var_decl name: [(ident) (ct_ident)] @variable.declaration)
-(try_unwrap (ident) @variable.declaration)
-(catch_unwrap (ident) @variable.declaration)
+[
+  "true"
+  "false"
+] @boolean
 
-;; Keyword (from `c3c --list-keywords`)
+"null" @constant.builtin
+
+; Variable
+[
+  (ident)
+  (ct_ident)
+  (hash_ident)
+] @variable
+
+; 1) Member
+(field_expr
+  field: (access_ident
+    (ident) @variable.member))
+
+(struct_member_declaration
+  (ident) @variable.member)
+
+(struct_member_declaration
+  (identifier_list
+    (ident) @variable.member))
+
+(bitstruct_member_declaration
+  (ident) @variable.member)
+
+(initializer_list
+  (initializer_element
+    (param_path
+      (param_path_element
+        (access_ident
+          (ident) @variable.member)))))
+
+; 2) Parameter
+(param
+  name: (_) @variable.parameter)
+
+(trailing_block_param
+  (at_ident) @variable.parameter)
+
+(call_arg_list
+  (call_arg
+    name: (_) @variable.parameter))
+
+(enum_param
+  (ident) @variable.parameter)
+
+; Keyword (from `c3c --list-keywords`)
 [
   "alias"
-  "assert"
   "asm"
+  "attrdef"
   "catch"
   "defer"
   "try"
@@ -40,9 +82,7 @@
 ] @keyword
 
 [
-  "$alignof"
   "$assert"
-  "$assignable"
   "$case"
   "$default"
   "$defined"
@@ -54,47 +94,45 @@
   "$endif"
   "$endswitch"
   "$eval"
-  "$evaltype"
   "$error"
   "$exec"
-  "$extnameof"
+  "$expand"
   "$feature"
   "$for"
   "$foreach"
   "$if"
   "$include"
-  "$is_const"
-  "$nameof"
-  "$offsetof"
-  "$qnameof"
-  "$sizeof"
+  "$reflect"
   "$stringify"
   "$switch"
   "$typefrom"
   "$typeof"
-  "$vacount"
-  "$vatype"
-  "$vaconst"
   "$vaarg"
-  "$vaexpr"
-  "$vasplat"
 ] @keyword.directive
 
+"assert" @keyword.debug
+
 "fn" @keyword.function
+
 "macro" @keyword.function
+
 "return" @keyword.return
-"import" @keyword.import
-"module" @keyword.module
+
+[
+  "import"
+  "module"
+] @keyword.import
 
 [
   "bitstruct"
   "enum"
-  "fault"
-  "inline"
+  "faultdef"
   "interface"
   "struct"
+  "typedef"
   "union"
-] @keyword
+  "constdef"
+] @keyword.type
 
 [
   "case"
@@ -123,36 +161,24 @@
   "tlocal"
 ] @keyword.modifier
 
-;; Operator (from `c3c --list-operators`)
+; Operator (from `c3c --list-operators`)
 [
   "&"
   "!"
   "~"
   "|"
   "^"
-  ;; ":"
-  ;; ","
-  ;; ";"
   "="
   ">"
   "/"
   "."
-  ;; "#"
   "<"
-  ;; "{"
-  ;; "["
-  ;; "("
   "-"
   "%"
   "+"
   "?"
-  ;; "}"
-  ;; "]"
-  ;; ")"
   "*"
-  ;; "_"
   "&&"
-  ;; "->"
   "!!"
   "&="
   "|="
@@ -164,9 +190,6 @@
   ">="
   "=>"
   "<="
-  ;; "{|"
-  ;; "(<"
-  ;; "[<"
   "-="
   "--"
   "%="
@@ -175,24 +198,32 @@
   "||"
   "+="
   "++"
-  ;; "|}"
-  ;; ">)"
-  ;; ">]"
   "??"
-  ;; "::"
   "<<"
   ">>"
   "..."
   "<<="
   ">>="
+  "&&&"
+  "+++"
+  "|||"
+  "???"
+  "+++="
 ] @operator
 
-(range_expr ":" @operator)
-(foreach_cond ":" @operator)
+(range_expr
+  ":" @operator)
+
+(foreach_cond
+  ":" @operator)
+
+(ct_foreach_cond
+  ":" @operator)
 
 (ternary_expr
   [
     "?"
+    "???"
     ":"
   ] @keyword.conditional.ternary)
 
@@ -202,125 +233,166 @@
     "??"
   ] @keyword.conditional.ternary)
 
-;; Literal
+; Literal
 (integer_literal) @number
+
 (real_literal) @number.float
+
 (char_literal) @character
+
 (bytes_literal) @number
 
-;; String
+; String
 (string_literal) @string
+
 (raw_string_literal) @string
 
-;; Escape Sequence
+; Escape Sequence
 (escape_sequence) @string.escape
 
-;; Builtin (constants)
-((builtin) @constant.builtin (#match? @constant.builtin "_*[A-Z][_A-Z0-9]*"))
+; Builtin (constants)
+(builtin_const) @constant.builtin
 
-;; Type Property (from `c3c --list-type-properties`)
-(type_access_expr (access_ident [(ident) "typeid"] @variable.builtin
-                                (#any-of? @variable.builtin
-                                          "alignof"
-                                          "associated"
-                                          "elements"
-                                          "extnameof"
-                                          "inf"
-                                          "is_eq"
-                                          "is_ordered"
-                                          "is_substruct"
-                                          "len"
-                                          "max"
-                                          "membersof"
-                                          "min"
-                                          "nan"
-                                          "inner"
-                                          "kindof"
-                                          "names"
-                                          "nameof"
-                                          "params"
-                                          "parentof"
-                                          "qnameof"
-                                          "returns"
-                                          "sizeof"
-                                          "values"
-                                          ;; Extra token
-                                          "typeid")))
+; Type Property
+(type_access_expr
+  (access_ident
+    (ident) @variable.builtin))
 
-;; Label
+; Label
 [
   (label)
   (label_target)
 ] @label
 
-;; Module
-(module_resolution (ident) @module)
-(module (path_ident (ident) @module))
-(import_declaration (path_ident (ident) @module))
+; Module
+(module_resolution
+  (ident) @module)
 
-;; Attribute
-(attribute name: (_) @attribute)
-(call_inline_attributes (at_ident) @attribute)
-(asm_block_stmt (at_ident) @attribute)
+(module_declaration
+  (path_ident
+    (ident) @module))
 
-;; Type
+(import_path
+  (path_ident
+    (ident) @module))
+
+; Attribute
+(attribute
+  name: (at_ident) @attribute)
+
+(at_type_ident) @attribute
+
+(call_inline_attributes
+  (at_ident) @attribute)
+
+(type_suffix
+  (at_ident) @attribute)
+
+(asm_block_stmt
+  (at_ident) @attribute)
+
+; Type
 [
   (type_ident)
   (ct_type_ident)
 ] @type
+
 (base_type_name) @type.builtin
 
-;; Function Definition
-(func_header name: (_) @function)
-(func_header method_type: (_) name: (_) @function.method)
-;; NOTE macro_declaration can also have a func_header
-(macro_header name: (_) @function)
-(macro_header method_type: (_) name: (_) @function.method)
+; Function Definition
+(func_header
+  name: (_) @function)
 
-;; Function Call
-(call_expr function: [(ident) (at_ident)] @function.call)
-(call_expr function: [(builtin)] @function.builtin.call)
-(call_expr function: (module_ident_expr ident: (_) @function.call))
-(call_expr function: (trailing_generic_expr argument: (module_ident_expr ident: (_) @function.call)))
-(call_expr function: (field_expr field: (access_ident [(ident) (at_ident)] @function.method.call))) ; NOTE Ambiguous, could be calling a method or function pointer
-;; Method on type
-(call_expr function: (type_access_expr field: (access_ident [(ident) (at_ident)] @function.method.call)))
+(func_header
+  method_type: (_)
+  name: (_) @function.method)
 
-;; Assignment
-;; (assignment_expr left: (ident) @variable.member)
-;; (assignment_expr left: (module_ident_expr (ident) @variable.member))
-;; (assignment_expr left: (field_expr field: (_) @variable.member))
-;; (assignment_expr left: (unary_expr operator: "*" @variable.member))
-;; (assignment_expr left: (subscript_expr ["[" "]"] @variable.member))
+(macro_header
+  name: (_) @function)
 
-;; (update_expr argument: (ident) @variable.member)
-;; (update_expr argument: (module_ident_expr ident: (ident) @variable.member))
-;; (update_expr argument: (field_expr field: (_) @variable.member))
-;; (update_expr argument: (unary_expr operator: "*" @variable.member))
-;; (update_expr argument: (subscript_expr ["[" "]"] @variable.member))
+(macro_header
+  method_type: (_)
+  name: (_) @function.method)
 
-;; (unary_expr operator: ["--" "++"] argument: (ident) @variable.member)
-;; (unary_expr operator: ["--" "++"] argument: (module_ident_expr (ident) @variable.member))
-;; (unary_expr operator: ["--" "++"] argument: (field_expr field: (access_ident (ident)) @variable.member))
-;; (unary_expr operator: ["--" "++"] argument: (subscript_expr ["[" "]"] @variable.member))
+; Function Call
+(call_expr
+  function: (ident_expr
+    [
+      (ident)
+      (at_ident)
+    ] @function.call))
 
-;; Asm
-(asm_instr [(ident) "int"] @function.builtin)
-(asm_expr [(ct_ident) (ct_const_ident)] @variable.builtin)
+(call_expr
+  function: (trailing_generic_expr
+    argument: (ident_expr
+      [
+        (ident)
+        (at_ident)
+      ] @function.call)))
 
-;; Comment
+; Method call
+(call_expr
+  function: (field_expr
+    field: (access_ident
+      [
+        (ident)
+        (at_ident)
+      ] @function.method.call)))
+
+; Method on type
+(call_expr
+  function: (type_access_expr
+    field: (access_ident
+      [
+        (ident)
+        (at_ident)
+      ] @function.method.call)))
+
+; Builtin call
+(call_expr
+  function: (builtin) @function.builtin)
+
+; Asm
+(asm_instr
+  [
+    (ident)
+    "int"
+  ] @function.builtin)
+
+(asm_expr
+  [
+    (ct_ident)
+    (ct_const_ident)
+  ] @variable.builtin)
+
+; Comment
 [
   (line_comment)
   (block_comment)
-] @comment
+] @comment @spell
 
-(doc_comment) @comment.doc
-(doc_comment_text) @comment.doc
-(doc_comment_contract name: (_) @emphasis.strong
-                      (#any-of? @emphasis.strong
-                                "@param"
-                                "@return"
-                                "@deprecated"
-                                "@require"
-                                "@ensure"
-                                "@pure"))
+(doc_comment) @comment.documentation
+
+(doc_comment_text) @spell
+
+(doc_comment_contract
+  name: (_) @attribute)
+
+(doc_comment_contract
+  parameter: [
+    (ident)
+    (ct_ident)
+    (hash_ident)
+  ] @variable.parameter
+  (#set! priority 110))
+
+(doc_comment_contract
+  [
+    ":"
+    "?"
+  ] @comment.documentation
+  (#set! priority 110))
+
+(doc_comment_contract
+  description: (_) @comment.documentation
+  (#set! priority 110))


### PR DESCRIPTION
Updates grammar. Supports 0.8.0 and also fixes issues that were happening with earlier versions, since the last update was quite some time ago.

<img width="380" alt="Screenshot 2026-05-13 at 18 17 03" src="https://github.com/user-attachments/assets/b08c4232-101e-428c-80ae-59f2a54ff47c" />

<img width="380" alt="Screenshot 2026-05-13 at 19 17 05" src="https://github.com/user-attachments/assets/debc0490-2f2b-486f-9639-1704090e7ba0" />
